### PR TITLE
[Added] PHP Compatibility Test Workflow

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -36,7 +36,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Set up PHP"
-        uses: shivammathur/setup-php@2
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -64,40 +64,57 @@ jobs:
         run: |
           parallel-lint --exclude tools -e php --show-deprecated ./
 
-  # php-compatibility:
+  php-compatibility:
 
-  #   strategy:
-  #     matrix:
-  #       php-version:
-  #         - '8.0'
-  #         - '8.1'
-  #         - '8.2'
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.0'
+          - '8.1'
+          - '8.2'
 
-  #   name: "PHP Compatibility"
-  #   runs-on: ${{ inputs.runs-on }}
-  #   timeout-minutes: 30
+    name: "PHP Compatibility"
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
 
-  #   steps:
+    steps:
 
-  #     - name: "Checks out the repository."
-  #       uses: "actions/checkout@v2"
+      - name: "Checks out the repository."
+        uses: "actions/checkout@v2"
 
-  #     - name: "Set up PHP"
-  #       uses: shivammathur/setup-php@2
-  #       with:
-  #         php-version: ${{ matrix.php-version }}
-  #         coverage: none
-  #         tools: composer, phpcs
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer,phpcs
 
-  #     - name: "Install PHPCompatibility"
+      - name: "Install PHPCompatibility"
+        run: |
+          composer global require phpcompatibility/php-compatibility
 
-  #     - name: "Build Project"
+      - name: "Get Composer Cache Directory."
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-  #     - name: Log debug information
-  #       run: |
-  #         php --version
-  #         phpcs --version
+      - name: "Sets up Caching."
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-composer-build-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-composer-build-
 
-  #     - name: "Run PHPCS on project specific files."
-  #       run: |
-  #         phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibility --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./public
+      - name: "Build site."
+        run: composer update --no-interaction --prefer-dist --no-scripts --no-dev
+
+      - name: Log debug information
+        run: |
+          php --version
+          phpcs --version
+
+      - name: "Run PHPCS on project specific files."
+        run: |
+          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibility --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -98,7 +98,7 @@ jobs:
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibilitywp:"*"
+          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility-wp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -93,11 +93,11 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
-          composer global config minimum-stability dev
-          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer global require --dev phpcsstandards/phpcsdevtools:^1.0
-          composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer global require phpcompatibility/php-compatibilitywp
+          composer config minimum-stability dev
+          composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer require --dev phpcsstandards/phpcsdevtools:^1.0
+          composer require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+          composer require phpcompatibility/php-compatibilitywp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -94,8 +94,7 @@ jobs:
       - name: "Install PHPCompatibility"
         run: |
           mkdir -p tools/php-compat
-          composer --working-dir=tools/php-compat init --no-interaction
-          composer --working-dir=tools/php-compat config minimum-stability dev
+          composer --working-dir=tools/php-compat init --name "vatu/php-compatibility" --stability dev
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,6 +1,6 @@
 # Vatu: PHP Compatibility
 # Description: Test the project against multiple php versions.
-# Version: 1.0.0-alpha
+# Version: 1.0.0
 # Author: Michael Bragg <mike@vatu.co.uk>
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require dealerdirect/phpcodesniffer-composer-installer
-          composer global require phpcompatibility/phpcompatibility-wp
+          composer global require phpcompatibility/phpcompatibility-wp:dev-develop as 9.99.99
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -95,9 +95,7 @@ jobs:
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require dealerdirect/phpcodesniffer-composer-installer
-          composer global config minimum-stability dev
-          composer global require phpcompatibility/php-compatibilitywp
-          composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+          composer global require phpcompatibility/phpcompatibility-wp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -94,6 +94,7 @@ jobs:
       - name: "Install PHPCompatibility"
         run: |
           mkdir -p tools/php-compat
+          composer --working-dir=tools/php-compat init --no-interaction
           composer --working-dir=tools/php-compat config minimum-stability dev
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,0 +1,86 @@
+# Vatu: PHP Compatibility
+# Description: Test the project against multiple php versions.
+# Version: 1.0.0-alpha
+# Author: Michael Bragg <mike@vatu.co.uk>
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: "PHP Compatatibility"
+
+on:
+  workflow_call:
+
+    inputs:
+      # Runner to be used by the parent workflow.
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+
+jobs:
+
+  php-lint:
+    strategy:
+      matrix:
+        php-version:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+
+    name: "PHP Lint"
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+
+    steps:
+
+      - name: "Checks out the repository."
+        uses: "actions/checkout@v2"
+
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: parallel-lint
+          ini-file: none
+
+      - name: "Run Parallel Lint test."
+        run: |
+          parallel-lint --exclude tools -e php --show-deprecated ./
+
+  # php-compatibility:
+
+  #   strategy:
+  #     matrix:
+  #       php-version:
+  #         - '8.0'
+  #         - '8.1'
+  #         - '8.2'
+
+  #   name: "PHP Compatibility"
+  #   runs-on: ${{ inputs.runs-on }}
+  #   timeout-minutes: 30
+
+  #   steps:
+
+  #     - name: "Checks out the repository."
+  #       uses: "actions/checkout@v2"
+
+  #     - name: "Set up PHP"
+  #       uses: shivammathur/setup-php@2
+  #       with:
+  #         php-version: ${{ matrix.php-version }}
+  #         coverage: none
+  #         tools: composer, phpcs
+
+  #     - name: "Install PHPCompatibility"
+
+  #     - name: "Build Project"
+
+  #     - name: Log debug information
+  #       run: |
+  #         php --version
+  #         phpcs --version
+
+  #     - name: "Run PHPCS on project specific files."
+  #       run: |
+  #         phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibility --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./public

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -98,6 +98,10 @@ jobs:
           composer global require phpcompatibility/phpcompatibility-wp
           phpcs -i
 
+      - name: "Download PHPCompatibility config"
+        run: curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/config/phpcompatibility.xml.dist
+        continue-on-error: true
+
       - name: "Get Composer Cache Directory."
         id: composer-cache
         run: |
@@ -121,4 +125,4 @@ jobs:
 
       - name: "Run PHPCS on project specific files."
         run: |
-          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./
+          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -98,7 +98,7 @@ jobs:
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibilitywp
+          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibilitywp:"*"
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist
           ls -la
-        continue-on-error: true
+        continue-on-error: false
 
       - name: "Get Composer Cache Directory."
         id: composer-cache

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -95,8 +95,8 @@ jobs:
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global config minimum-stability dev
-          composer global require dealerdirect/phpcodesniffer-composer-installer
           composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+          composer global require phpcompatibility/php-compatibilitywp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -97,7 +97,6 @@ jobs:
           composer global config minimum-stability dev
           composer global require dealerdirect/phpcodesniffer-composer-installer
           composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer global require phpcompatibility/php-compatibilitywp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
-          composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require dealerdirect/phpcodesniffer-composer-installer
           composer global require phpcompatibility/php-compatibility
           phpcs -i

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -99,7 +99,7 @@ jobs:
           phpcs -i
 
       - name: "Download PHPCompatibility config"
-        run: curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/config/phpcompatibility.xml.dist
+        run: curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist
         continue-on-error: true
 
       - name: "Get Composer Cache Directory."

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -100,8 +100,7 @@ jobs:
 
       - name: "Download PHPCompatibility config"
         run: |
-          curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist
-          ls -la
+          curl -L https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist --output phpcompatibility.xml.dist --fail
         continue-on-error: false
 
       - name: "Get Composer Cache Directory."

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -129,4 +129,4 @@ jobs:
 
       - name: "Run PHPCS on project specific files."
         run: |
-          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./
+          phpcs -p -s --colors --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -28,7 +28,7 @@ jobs:
           - '8.1'
           - '8.2'
 
-    name: "PHP Lint"
+    name: "PHP Lint ${{ matrix.php-version }}"
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 10
 
@@ -75,7 +75,7 @@ jobs:
           - '8.1'
           - '8.2'
 
-    name: "PHP Compatibility"
+    name: "PHP Compatibility ${{ matrix.php-version }}"
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 10
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -98,7 +98,7 @@ jobs:
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility-wp:"*"
+          composer --working-dir=tools/php-compat require phpcompatibility/phpcompatibility-wp:"*"
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -93,6 +93,7 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
+          mkdir -p tools/php-compat
           composer --working-dir=tools/php-compat config minimum-stability dev
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -93,11 +93,11 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
-          composer config minimum-stability dev
-          composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer require --dev phpcsstandards/phpcsdevtools:^1.0
-          composer require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer require phpcompatibility/php-compatibilitywp
+          composer --working-dir=tools/php-compat config minimum-stability dev
+          composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
+          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibilitywp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -98,7 +98,7 @@ jobs:
           composer --working-dir=tools/php-compat config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
-          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility-wp
+          composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility-wp:"*"
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,8 +10,9 @@ on:
   workflow_call:
 
     inputs:
-      # Runner to be used by the parent workflow.
+
       runs-on:
+        description: "Runner to be used by the parent workflow."
         required: false
         type: string
         default: ubuntu-latest
@@ -94,7 +95,7 @@ jobs:
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require dealerdirect/phpcodesniffer-composer-installer
-          composer global require phpcompatibility/php-compatibility
+          composer global require phpcompatibility/phpcompatibility-wp
           phpcs -i
 
       - name: "Get Composer Cache Directory."
@@ -120,4 +121,4 @@ jobs:
 
       - name: "Run PHPCS on project specific files."
         run: |
-          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibility --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./
+          phpcs -p -s --colors --error-severity=1 --warning-severity=8 --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -20,6 +20,7 @@ jobs:
 
   php-lint:
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - '8.0'

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -94,8 +94,10 @@ jobs:
       - name: "Install PHPCompatibility"
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global config minimum-stability dev
           composer global require dealerdirect/phpcodesniffer-composer-installer
-          composer global require phpcompatibility/phpcompatibility-wp
+          composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
+          composer global require phpcompatibility/php-compatibilitywp
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -129,4 +129,5 @@ jobs:
 
       - name: "Run PHPCS on project specific files."
         run: |
-          phpcs -p -s --colors --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./
+          ls -la
+          phpcs -p -s --colors --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./ -v

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -95,7 +95,9 @@ jobs:
         run: |
           composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require dealerdirect/phpcodesniffer-composer-installer
-          composer global require phpcompatibility/phpcompatibility-wp:dev-develop as 9.99.99
+          composer global config minimum-stability dev
+          composer global require phpcompatibility/php-compatibilitywp
+          composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
           phpcs -i
 
       - name: "Download PHPCompatibility config"

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -40,8 +40,24 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
-          tools: parallel-lint
+          tools: composer,parallel-lint
           ini-file: none
+
+      - name: "Get Composer Cache Directory."
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: "Sets up Caching."
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-composer-build-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-composer-build-
+
+      - name: "Build site."
+        run: composer update --no-interaction --prefer-dist --no-scripts --no-dev
 
       - name: "Run Parallel Lint test."
         run: |

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -93,8 +93,9 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
-          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global config minimum-stability dev
+          composer global config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require --dev phpcsstandards/phpcsdevtools:^1.0
           composer global require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
           composer global require phpcompatibility/php-compatibilitywp
           phpcs -i

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -92,7 +92,10 @@ jobs:
 
       - name: "Install PHPCompatibility"
         run: |
+          composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require dealerdirect/phpcodesniffer-composer-installer
           composer global require phpcompatibility/php-compatibility
+          phpcs -i
 
       - name: "Get Composer Cache Directory."
         id: composer-cache

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -84,7 +84,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Set up PHP"
-        uses: shivammathur/setup-php@2
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -99,7 +99,9 @@ jobs:
           phpcs -i
 
       - name: "Download PHPCompatibility config"
-        run: curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist
+        run: |
+          curl --fail -o phpcompatibility.xml.dist https://github.com/vatu-team/workflows/raw/php-compatability/config/phpcompatibility.xml.dist
+          ls -la
         continue-on-error: true
 
       - name: "Get Composer Cache Directory."

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -99,7 +99,6 @@ jobs:
           composer --working-dir=tools/php-compat require --dev phpcsstandards/phpcsdevtools:^1.0
           composer --working-dir=tools/php-compat require phpcompatibility/php-compatibility:"dev-develop as 9.99.99"
           composer --working-dir=tools/php-compat require phpcompatibility/phpcompatibility-wp:"*"
-          phpcs -i
 
       - name: "Download PHPCompatibility config"
         run: |
@@ -126,8 +125,8 @@ jobs:
         run: |
           php --version
           phpcs --version
+          phpcs -i
 
       - name: "Run PHPCS on project specific files."
         run: |
-          ls -la
-          phpcs -p -s --colors --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./ -v
+          phpcs -p -s --colors --standard=phpcompatibility.xml.dist --extensions=php --runtime-set testVersion ${{ matrix.php-version }} ./

--- a/config/phpcompatibility.xml.dist
+++ b/config/phpcompatibility.xml.dist
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<ruleset name="Vatu PHP Compatibility">
+	<description>Apply PHP compatibility checks to all project files</description>
+
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20"/>
+
+	<!-- Show sniff codes in all reports. -->
+	<arg value="ps"/>
+
+	<!-- Code which doesn't go into production may have different requirements. -->
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<!--
+		PHPCompatibilityParagonieSodiumCompat prevents false positives in `sodium_compat`.
+		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.
+	-->
+	<exclude-pattern>src/wp-includes/sodium_compat/lib/php72compat_const\.php$</exclude-pattern>
+
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_keypair_from_secretkey_and_publickeyFound">
+		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_padFound">
+		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_unpadFound">
+		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
+	</rule>
+
+	<!--
+		PHPCompatibilityParagonieRandomCompat prevents false positives in `random_compat`.
+		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.
+	-->
+	<rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated">
+		<exclude-pattern>/random_compat/byte_safe_strings\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_dev_urandomDeprecatedRemoved">
+		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved">
+		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
+		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Allow the WP DB Class for use of `mysql_` extension in PHP < 7.0. -->
+	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved">
+		<exclude-pattern>*/wp/wp-includes/wp-db\.php</exclude-pattern>
+	</rule>
+</ruleset>

--- a/config/phpcompatibility.xml.dist
+++ b/config/phpcompatibility.xml.dist
@@ -4,6 +4,21 @@
 
 	<rule ref="PHPCompatibilityWP"/>
 
+	<!-- WordPress Core currently supports PHP 7.4+. -->
+	<config name="testVersion" value="7.4-"/>
+
+	<!-- Only scan PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<!-- <arg name="cache" value=".cache/phpcompat.json"/> -->
+
+	<!-- Set the memory limit to 256M.
+		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
+		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
+	-->
+	<ini name="memory_limit" value="256M"/>
+
 	<!-- Strip the filepaths down to the relevant bit. -->
 	<arg name="basepath" value="./"/>
 
@@ -15,12 +30,13 @@
 
 	<!-- Code which doesn't go into production may have different requirements. -->
 	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/tools/*</exclude-pattern>
 
 	<!--
 		PHPCompatibilityParagonieSodiumCompat prevents false positives in `sodium_compat`.
 		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.
 	-->
-	<exclude-pattern>src/wp-includes/sodium_compat/lib/php72compat_const\.php$</exclude-pattern>
+	<exclude-pattern>/wp-includes/sodium_compat/lib/php72compat_const\.php$</exclude-pattern>
 
 	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_keypair_from_secretkey_and_publickeyFound">
 		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
@@ -51,6 +67,6 @@
 
 	<!-- Allow the WP DB Class for use of `mysql_` extension in PHP < 7.0. -->
 	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved">
-		<exclude-pattern>*/wp/wp-includes/wp-db\.php</exclude-pattern>
+		<exclude-pattern>/wp-includes/wp-db\.php</exclude-pattern>
 	</rule>
 </ruleset>

--- a/config/phpcompatibility.xml.dist
+++ b/config/phpcompatibility.xml.dist
@@ -66,4 +66,18 @@
 	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved">
 		<exclude-pattern>/wp-includes/wp-db\.php</exclude-pattern>
 	</rule>
+
+	<!--
+		Guzzle (https://github.com/guzzle/)
+	-->
+
+	<!--
+		False Positive:
+		Provides its own fallback for `each()`. See: https://github.com/guzzle/promises/blob/master/src/functions.php#L258
+	-->
+	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.eachDeprecated">
+		<exclude-pattern>/vendor/guzzlehttp/promises/src/functions\.php</exclude-pattern>
+		<exclude-pattern>/vendor/guzzlehttp/promises/src/Utils\.php</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/config/phpcompatibility.xml.dist
+++ b/config/phpcompatibility.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Vatu PHP Compatibility">
+	<!-- Version 1.0.0 -->
 	<description>Apply PHP compatibility checks to all project files</description>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/config/phpcompatibility.xml.dist
+++ b/config/phpcompatibility.xml.dist
@@ -4,9 +4,6 @@
 
 	<rule ref="PHPCompatibilityWP"/>
 
-	<!-- WordPress Core currently supports PHP 7.4+. -->
-	<config name="testVersion" value="7.4-"/>
-
 	<!-- Only scan PHP files. -->
 	<arg name="extensions" value="php"/>
 


### PR DESCRIPTION
Adds support for testing the whole project against PHP8.0, 8.1, and 8.2.

Validity is based on PHP Parallel Lint and PHP Compatibility dependencies.